### PR TITLE
Feat/p2 gaps

### DIFF
--- a/src-electron/db/procedures/inventory.js
+++ b/src-electron/db/procedures/inventory.js
@@ -24,6 +24,18 @@ function nz(v) { return v === undefined ? null : v; }
 function coalesce(v, fallback) { return v === null || v === undefined ? fallback : v; }
 
 /**
+ * Normalises a HUID for storage: trims, uppercases, and coerces blank to NULL.
+ * The `uk_products_huid` UNIQUE index permits many NULLs but only one ''; a
+ * blank must become NULL so untagged products don't collide. Uppercasing keeps
+ * stored HUIDs consistent with how they're searched/scanned.
+ */
+function normHuid(v) {
+  if (v === null || v === undefined) { return null; }
+  const s = String(v).trim().toUpperCase();
+  return s.length ? s : null;
+}
+
+/**
  * Local helper — replaces the product image-name idiom
  *   CONCAT(UNIX_TIMESTAMP(), '-product-', <guid>, '.', SUBSTRING_INDEX(name,'.',-1))
  * used by add_product / update_product_image. NOTE: this format is product-
@@ -66,7 +78,9 @@ function add_product(db, params) {
         hsnCode, imagePath, isSold, mid, sid, pid
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`
   ).run(
-    guid, nz(sku), nz(huid), nz(purityCode), nz(productDescription),
+    // huid: coerce blank -> NULL (SQLite UNIQUE allows many NULLs but not many
+    // ''), and normalise to uppercase to match how HUIDs are searched/scanned.
+    guid, nz(sku), normHuid(huid), nz(purityCode), nz(productDescription),
     toMg(grossWeight), toMg(netWeight), toMg(stoneWeight), toPaise(stoneCharges),
     coalesce(makingMode, 'perGram'), toPaise(makingValue), nz(wastagePercent),
     toPaise(costPrice), toPaise(tagPrice), coalesce(hsnCode, '7113'),
@@ -187,7 +201,7 @@ function update_product_details(db, params) {
             pid                = ?
       WHERE productGuid = ?`
   ).run(
-    nz(sku), nz(huid), nz(purityCode), nz(productDescription),
+    nz(sku), normHuid(huid), nz(purityCode), nz(productDescription),
     toMg(grossWeight), toMg(netWeight), toMg(stoneWeight), toPaise(stoneCharges),
     nz(makingMode), toPaise(makingValue), nz(wastagePercent),
     toPaise(costPrice), toPaise(tagPrice), nz(hsnCode),

--- a/src-electron/db/procedures/oldGold.js
+++ b/src-electron/db/procedures/oldGold.js
@@ -157,8 +157,41 @@ function get_old_gold_receipts_by_customer(db, params) {
   return [hydrateRows(rows).map(withCustomerName)];
 }
 
+/**
+ * delete_old_gold_receipt(p_receiptGuid, p_actorUserId)
+ * Deletes an old-gold receipt ONLY while it is unbilled (invoiceId IS NULL) —
+ * used when the cart removes an old-gold entry before the sale is saved, so the
+ * standalone receipt row isn't left orphaned. A receipt already linked to an
+ * invoice is left untouched (returns deleted: 0). Audits on delete.
+ */
+function delete_old_gold_receipt(db, params) {
+  const [p_receiptGuid, p_actorUserId] = params;
+
+  const run = db.transaction(() => {
+    const row = db.prepare(
+      'SELECT id, invoiceId FROM oldgoldreceipts WHERE receiptGuid = ?'
+    ).get(nz(p_receiptGuid));
+
+    if (!row) { return { deleted: 0 }; }
+    if (row.invoiceId != null) { return { deleted: 0 }; } // billed -> keep
+
+    db.prepare('DELETE FROM oldgoldreceipts WHERE id = ?').run(row.id);
+    writeAudit(db, {
+      actorUserId: nz(p_actorUserId),
+      action: 'delete_old_gold_receipt',
+      entity: 'oldgoldreceipts',
+      entityId: row.id,
+      after: { receiptGuid: nz(p_receiptGuid) },
+    });
+    return { deleted: 1 };
+  });
+
+  return [[hydrateRow(run())]];
+}
+
 module.exports = {
   save_old_gold_receipt,
   get_old_gold_receipt_by_invoice,
   get_old_gold_receipts_by_customer,
+  delete_old_gold_receipt,
 };


### PR DESCRIPTION
This pull request introduces several improvements to the inventory and old gold receipt handling logic, focusing on data consistency and safe deletion. The main changes include normalizing HUID values to prevent uniqueness conflicts, and adding a new procedure to safely delete unbilled old gold receipts. 

**Inventory data consistency:**
- Added a `normHuid` function to normalize HUID values by trimming, uppercasing, and converting blanks to `NULL`, ensuring consistent storage and preventing uniqueness conflicts in the `uk_products_huid` index. (`src-electron/db/procedures/inventory.js`)
- Updated both `add_product` and `update_product_details` procedures to use `normHuid` for HUID normalization before storing in the database. (`src-electron/db/procedures/inventory.js`) [[1]](diffhunk://#diff-8fcbe1a5cf45e2487af4af39284a4d3dc36195028745128465dd3fad94704760L69-R83) [[2]](diffhunk://#diff-8fcbe1a5cf45e2487af4af39284a4d3dc36195028745128465dd3fad94704760L190-R204)

**Old gold receipt management:**
- Added a new `delete_old_gold_receipt` procedure that deletes an old gold receipt only if it is unbilled (i.e., not linked to an invoice), preventing orphaned receipts and ensuring proper auditing on deletion. (`src-electron/db/procedures/oldGold.js`)

**Dependency update:**
- Updated the `client` submodule to a new commit, possibly bringing in upstream fixes or features. (`client`)